### PR TITLE
jwt 패키지 완성

### DIFF
--- a/ilkda/src/main/java/com/ilkda/server/auth/service/AuthService.java
+++ b/ilkda/src/main/java/com/ilkda/server/auth/service/AuthService.java
@@ -88,7 +88,7 @@ public class AuthService {
             throw new UnauthorizedException("ACCESS 토큰을 갱신할 수 없습니다.");
         }
 
-        Long memberId = ((MemberJwtPayload)memberJwtUtil.getPayload()).getMember_id();
+        Long memberId = memberJwtUtil.getPayload().getMember_id();
         if(!memberService.existsMember(memberId)) {
             throw new NotFoundException("존재하지 않는 회원입니다.");
         }
@@ -109,7 +109,7 @@ public class AuthService {
                     MemberJwtPayload.builder()
                     .type(JwtPayload.JwtType.REFRESH)
                     .exp(System.currentTimeMillis() + REFRESH_TOKEN_DURATION)
-                    .member_id(((MemberJwtPayload)memberJwtUtil.getPayload()).getMember_id())
+                    .member_id(memberJwtUtil.getPayload().getMember_id())
                     .build());
         }
         return refreshToken;

--- a/ilkda/src/main/java/com/ilkda/server/jwt/JwtGenerator.java
+++ b/ilkda/src/main/java/com/ilkda/server/jwt/JwtGenerator.java
@@ -1,6 +1,7 @@
 package com.ilkda.server.jwt;
 
 import com.ilkda.server.exception.UnauthorizedException;
+import com.ilkda.server.jwt.payload.JwtPayload;
 import com.ilkda.server.jwt.payload.MemberJwtPayload;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -17,7 +18,7 @@ public class JwtGenerator {
     @Value("${jwt.secret}")
     private String SECRET_KEY;
 
-    private String doGenerate(MemberJwtPayload payload) throws IllegalAccessException {
+    private String doGenerate(JwtPayload payload) throws IllegalAccessException {
         SECRET_KEY = Base64.getEncoder().encodeToString(SECRET_KEY.getBytes());
         Claims claims = Jwts.claims(payload.getPayloads());
         return Jwts.builder()

--- a/ilkda/src/main/java/com/ilkda/server/jwt/util/JwtUtil.java
+++ b/ilkda/src/main/java/com/ilkda/server/jwt/util/JwtUtil.java
@@ -3,30 +3,17 @@ package com.ilkda.server.jwt.util;
 import com.ilkda.server.exception.UnauthorizedException;
 import com.ilkda.server.jwt.payload.JwtPayload;
 
-public abstract class JwtUtil {
+public interface JwtUtil {
 
-    private final String token;
-    private final JwtPayload payload;
+    String getToken();
 
-    public JwtUtil(String token) {
-        this.token = token;
-        this.payload = parsePayload();
-        validateToken();
-    }
+    JwtPayload getPayload();
 
-    public String getToken() {
-        return this.token;
-    }
-
-    public JwtPayload getPayload() {
-        return this.payload;
-    }
-
-    private void validateToken() {
-        if(payload.getExp() < System.currentTimeMillis()) {
+    default void validateExpiration(long expiration) {
+        if(expiration < System.currentTimeMillis()) {
             throw new UnauthorizedException("토큰이 유효하지 않습니다.");
         }
     }
 
-    abstract JwtPayload parsePayload();
+    JwtPayload parsePayload();
 }

--- a/ilkda/src/main/java/com/ilkda/server/jwt/util/MemberJwtUtil.java
+++ b/ilkda/src/main/java/com/ilkda/server/jwt/util/MemberJwtUtil.java
@@ -26,8 +26,7 @@ public class MemberJwtUtil implements JwtUtil {
         return this.token;
     }
 
-    @Override
-    public JwtPayload getPayload() {
+    public MemberJwtPayload getPayload() {
         return this.payload;
     }
 

--- a/ilkda/src/main/java/com/ilkda/server/jwt/util/MemberJwtUtil.java
+++ b/ilkda/src/main/java/com/ilkda/server/jwt/util/MemberJwtUtil.java
@@ -1,6 +1,7 @@
 package com.ilkda.server.jwt.util;
 
 import com.ilkda.server.exception.UnauthorizedException;
+import com.ilkda.server.jwt.payload.JwtPayload;
 import com.ilkda.server.jwt.payload.MemberJwtPayload;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -8,10 +9,26 @@ import org.json.simple.parser.ParseException;
 
 import java.util.*;
 
-public class MemberJwtUtil extends JwtUtil {
+public class MemberJwtUtil implements JwtUtil {
+
+    private String token;
+    private MemberJwtPayload payload;
 
     public MemberJwtUtil(String token) {
-        super(token);
+        this.token = token;
+        this.payload = parsePayload();
+
+        validateExpiration(payload.getExp());
+    }
+
+    @Override
+    public String getToken() {
+        return this.token;
+    }
+
+    @Override
+    public JwtPayload getPayload() {
+        return this.payload;
     }
 
     /**

--- a/ilkda/src/main/java/com/ilkda/server/security/provider/JwtProvider.java
+++ b/ilkda/src/main/java/com/ilkda/server/security/provider/JwtProvider.java
@@ -4,7 +4,6 @@ import com.ilkda.server.jwt.util.MemberJwtUtil;
 import com.ilkda.server.security.AuthenticationToken;
 import com.ilkda.server.security.details.CustomUserDetails;
 import com.ilkda.server.security.details.CustomUserDetailsService;
-import com.ilkda.server.jwt.payload.MemberJwtPayload;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -22,7 +21,7 @@ public class JwtProvider implements AuthenticationProvider {
 
         MemberJwtUtil memberJwtUtil = new MemberJwtUtil(accessToken);
         CustomUserDetails userDetails = (CustomUserDetails) userDetailsService.loadUserByUsername(
-                String.valueOf(((MemberJwtPayload)memberJwtUtil.getPayload()).getMember_id()));
+                String.valueOf(memberJwtUtil.getPayload().getMember_id()));
 
         return new UsernamePasswordAuthenticationToken(
                 userDetails,


### PR DESCRIPTION
## jwt 패키지에 대하여
jwt 관련 기능이 많고, 하나의 단위가 된다고 판단하여 기존 jwt 관련 클래스들을 jwt 패키지로 분리하여 모았습니다.

### 1. payload
JwtPayload 인터페이스에는 jwt에 필요한 필수 스펙들이 포함되어 있습니다. 새로운 양식의 토큰이 추가되는 경우에 본 인터페이스를 구현하면 됩니다.
- 토큰은 기본적으로 타입과 만료시간을 포함해야 하므로, 구현 클래스에서 각 필드를 포함하도록 getter 함수를 추가했습니다.
- 토큰 생성 시 map 형태로의 변환이 필요하므로, 구현클래스에서 각 필드와 값을 map에 저장하는 구조를 포함하도록 getPayloads() 함수를 추가했습니다.
- 본 서비스에서는 현재 사용자 인증 관련 jwt를 사용하기 위해 MemberJwtPayload 클래스에서 본 인터페이스를 구현했습니다.
- 페이로드 구성은 생성 시 일괄적으로 수행하도록 Setter는 따로 마련하지 않았습니다.

### 2. util
JwtUtil 인터페이스는 토큰 내 정보를 활용할 때 사용할 수 있습니다. 새로운 종류의 토큰을 활용할 때 본 인터페이스를 구현하면 됩니다.
- 해당 기능은 기본적으로 토큰 문자열과 해당 jwt의 페이로드 객체를 포함해야 하므로, 구현 클래스에서 각 필드를 포함하도록 getter 함수를 추가했습니다.
- 토큰은 기본적으로 만료 여부를 확인해야 하므로 해당 로직을 default 함수로 추가했습니다.
- 각 토큰에 대하여 토큰 문자열을 페이로드 객체로 파싱하여 반환할 수 있도록 파싱 함수를 추가했습니다.
- 본 서비스에서는 현재 사용자 인증 관련 jwt를 사용하기 위해 MemberJwtUtil 클래스에서 본 인터페이스를 구현했습니다.
- getPayload() 함수의 경우, 매 호출 시마다 하위 클래스로 casting 할 필요가 없도록 반환 타입을 MemberJwtUtil로 지정했습니다.

### 3. generator
JwtGenerator는 각 페이로드를 포함하는 토큰을 생성하는 역할을 담당합니다.
- 새로운 토큰 생성이 필요하다면, generateXXXToken 함수를 선언해 페이로드 객체를 doGenerate 함수에 전달하면 됩니다.
- doGenerate 함수 파라미터 타입은 다양한 형태의 페이로드를 모두 수용하도록 JwtPayload 인터페이스로 지정했습니다.

<br>

** 리팩토링 과정은 #9 에서 이어집니다.
** 2023/4/7 현재 jwtUtil 인터페이스는 추상 클래스로 수정되었습니다. #15 